### PR TITLE
Remove preinstall submodule hook in package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 npm install coffee-script lua-distiller -g
 ```
 
+[LuaSrcDiet][] 是可选依赖。如果如果需要 minify 功能，
+请确保 `LuaSrcDiet.lua` 在 `$PATH` 中。
+
+[LuaSrcDiet]: https://github.com/LuaDist/luasrcdiet/tree/486129fa1ef1539071d14a366d686f3892c3d43f
+
 ## Usage 用法
 
 Use in command line

--- a/bin/lua-distiller.coffee
+++ b/bin/lua-distiller.coffee
@@ -86,8 +86,6 @@ OUTPUT_PATH_MINIFIED_LUA = ""
 OUTPUT_PATH_MERGED_JIT = ""
 OUTPUT_PATH_MINIFIED_JIT = ""
 
-PATH_TO_LUA_SRC_DIET = path.resolve(__dirname, "../luasrcdiet/")
-#console.log "[lua-distiller::PATH_TO_LUA_SRC_DIET] #{PATH_TO_LUA_SRC_DIET}"
 
 PATH_TO_LUA_JIT = which "luajit"
 #console.log "[lua-distiller::PATH_TO_LUA_JIT] #{PATH_TO_LUA_JIT}"
@@ -226,7 +224,7 @@ fs.writeFileSync OUTPUT_PATH_MERGED_LUA, result
 
 if p.minify
   console.log "minify merged lua file to: #{OUTPUT_PATH_MINIFIED_LUA}"
-  exec "cd #{PATH_TO_LUA_SRC_DIET} && ./LuaSrcDiet.lua #{OUTPUT_PATH_MERGED_LUA} -o #{OUTPUT_PATH_MINIFIED_LUA} "
+  exec "LuaSrcDiet.lua #{OUTPUT_PATH_MERGED_LUA} -o #{OUTPUT_PATH_MINIFIED_LUA} "
 
 if p.luajitify
   console.log "luajit compile merged lua file to #{OUTPUT_PATH_MERGED_JIT}"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "bin": {
       "lua-distill": "./bin/lua-distiller.coffee"
     },
-    "scripts":{"preinstall": "git submodule update -i -r"},
     "repository": {
       "type": "git",
       "url": "git://github.com/yi/node-lua-distiller.git"


### PR DESCRIPTION
Using `git submodule` to install LuaSrcDiet is convenient for local module,
but does not fit global installed module.
Since there is no git repository in global node_modules path
on most systems.

Considering LuaSrcDiet is an optional dependence,
I just removed the preinstall line calling `git submodule`,
and ask users to install LuaSrcDiet themselves in README.

I think this fixes #1
