### PR TITLE
bugfix：修复同一个文件被不同格式require后，会生成多份代码的bug，导致lua的逻辑错误

### DIFF
--- a/bin/lua-distiller.coffee
+++ b/bin/lua-distiller.coffee
@@ -137,10 +137,11 @@ scan = (filename, requiredBy) ->
 
     #continue if ~EXCLUDE_PACKAGE_NAMES.indexOf(module)
 
+    module = "#{module.replace(/\./g, '/')}"
     # 忽略已经被摘取的模块, 但要提高这个依赖模块的排名
     continue if MODULES[module]
 
-    pathToModuleFile = "#{module.replace(/\./g, '/')}.lua"
+    pathToModuleFile = module + ".lua"
     pathToModuleFile = path.normalize(path.join(BASE_FILE_PATH, pathToModuleFile))
 
     # run recesively


### PR DESCRIPTION
例如，有三个文件：
 dir/a.lua    |          b.lua                |           c.lua
local x = {}  |  local a = require('dir/a')   |   local a = require('dir.a')
return x      |

会在MODULES里生成两份a.lua的代码，一份id='dir/a'，另一份id='dir.a'，
从而在b、c里require会分别取到两块不同内存。